### PR TITLE
Bugfix/slow write speed and 20x4 lcd problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Building the advanced usage example: go to the directory example_backlight. Foll
 ![](img/blconnect.png)
 
 ## Release notes
+26-jun-2024: speed up writes, fix character position for 4-line displays, add single char write function
 4-mar-2021: added some useful methods to the library<br>
 3 -mar-2021: Added backlight option<br>
 27-feb-2021: First release

--- a/lcd_display/lcd_display.hpp
+++ b/lcd_display/lcd_display.hpp
@@ -43,7 +43,11 @@ class LCDdisplay {
 	void init() ;
 
 	void goto_pos(int pos, int line);
+
+	// Write a single character
+	void write(const char chr);
 	
+	// Print a string
 	void print(const char * str);
 		
 	void print_wrapped(const char * str);


### PR DESCRIPTION
I made a number of improvements to the code:

* Reduced write cycle time so that writes to the display are much faster
* Rewrote cursor position calculation for 4-line displays so that cursor appears where expected
* Added 'write' function to write a single character as per the convention set by many other libraries